### PR TITLE
Run CI only with the Python version we use

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -12,15 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.7.5
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Our tests were executed with three different Python versions while we use 3.7.5 locally. This was a waste of resources and time.